### PR TITLE
set NODE_ENV for install & run web server

### DIFF
--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -40,16 +40,12 @@
     dest: /opt/caliopen
 
 - name: install node packages
-  shell: yarn
+  shell: NODE_ENV=production yarn
   args:
     chdir: /opt/caliopen/client
-
-- name: install client launcher
-  template: src=start-client.j2 dest=/opt/caliopen/client/start-client mode=0755
 
 - name: install web client service
   template: src=web-client.service.j2 dest=/etc/systemd/system/web-client.service
 
 - name: start web client service
   service: name=web-client state=started
-

--- a/roles/client/templates/start-client.j2
+++ b/roles/client/templates/start-client.j2
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('./dist/server');

--- a/roles/client/templates/web-client.service.j2
+++ b/roles/client/templates/web-client.service.j2
@@ -4,7 +4,7 @@ Description=Caliopen web client
 [Service]
 Environment
 WorkingDirectory=/opt/caliopen/client
-ExecStart=start-client
+ExecStart=yarn start:prod
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I didn't test the following changes w/ ansible.

Also I've incertitude about how and who must control the NODE_ENV. 
My though goes for the op who is launching the server.

Also there's multiple ways to start the server, we have to set the official way (those do the exact same thing):

* `yarn start:prod`
* `NODE_ENV=production bin/server`
* `NODE_ENV=production node dist/server/index.js`
