### PR TITLE
Feature/local external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ Setup
 (*) can use a wildcard certificate and put same files in all roles
 (**) this repository contain the encrypted private key for alpha.caliopen.org domain. Encryption is done using ansible vault.
 
+External dependencies
+---------------------
+
+External dependencies must be downloaded and build in local {{ dist_directory }}/ext directory
+
+A local playbook must be used:
+
+```
+ansible-playbook -i hosts get_external_dependencies.yaml -e @external_version.ini
+```
+
 Deployment
 ----------
 

--- a/bin/create_gandi_vm.sh
+++ b/bin/create_gandi_vm.sh
@@ -33,7 +33,7 @@ gandi vm create --memory 1024 --hostname lmtp1 --image "Debian 8" --size 10G --d
 gandi vm create --memory 1024 --hostname web-client1 --image "Debian 8" --size 10G --datacenter FR-SD3 --vlan alpha_vlan --ip 192.168.1.120 --ip-version 4
 
 # worker
-gandi vm create --memory 1024 --hostname worker1 --image "Debian 8" --size 10G --datacenter FR-SD3 --vlan alpha_vlan --ip 192.168.1.150 --ip-version 4
+gandi vm create --memory 1024 --hostname worker1 --image "Debian 8" --size 10G --datacenter FR-SD3 --vlan alpha_vlan --ip 192.168.1.150 --ip-version 6
 
 # SMTP
 # vlan ip range for smtp services : 192.168.1.32/29

--- a/external_version.yaml
+++ b/external_version.yaml
@@ -1,0 +1,16 @@
+
+dist_directory: "./dist"
+
+# Version of installed software out of host packaging
+
+# monitoring platform
+prometheus_version: "1.7.2"
+alertmanager_version: "0.9.1"
+
+# gnats
+gnats_version: "1.0.2"
+
+# prometheus exporters
+redis_exporter_version: "0.12.2"
+jmx_prometheus_javaagent_version: "0.9"
+node_exporter_version: "0.14.0"

--- a/get_external_dependencies.yaml
+++ b/get_external_dependencies.yaml
@@ -1,0 +1,71 @@
+# 
+# Ansible local playbook to get all external dependencies needed for caliopen platform
+#
+# You must have a defined $GOPATH and go >= 1.8 compiler
+
+- hosts: 127.0.0.1
+  connection: local
+  tasks:
+    # nats server
+    - name: download nats server
+      get_url:
+        url: "https://github.com/nats-io/gnatsd/releases/download/v{{ gnats_version }}/gnatsd-v{{ gnats_version }}-linux-amd64.zip"
+        dest: "{{ dist_directory }}/ext/gnatsd-v{{ gnats_version }}-linux-amd64.zip"
+
+    - name: unzip nats server
+      unarchive:
+        src: "{{ dist_directory }}/ext/gnatsd-v{{ gnats_version }}-linux-amd64.zip"
+        dest: "{{ dist_directory }}/ext/"
+
+    # prometheus nats exporter
+    - name: download prometheus-nats-exporter
+      git:
+        repo: git@github.com:nats-io/prometheus-nats-exporter.git
+        dest: "{{ ansible_env['GOPATH']}}/nats-io/prometheus-nats-exporter"
+
+    - name: build prometheus-nats-exporter
+      shell: go build
+      args:
+        chdir: "{{ ansible_env['GOPATH']}}/nats-io/prometheus-nats-exporter"
+
+    - name: copy prometheus-nats-exporter
+      copy:
+        src: "{{ ansible_env['GOPATH']}}/nats-io/prometheus-nats-exporter/prometheus-nats-exporter"
+        dest: "{{ dist_directory }}/ext/prometheus-nats-exporter"
+
+    # get alert manager release
+    - name: download alertmanager
+      get_url:
+        url: https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz
+        dest: "{{ dist_directory }}/ext/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz"
+
+    - name: decompress alertmanager
+      shell: "tar xzvf alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz"
+      args:
+        chdir: "{{ dist_directory }}/ext"
+
+    # redis prometheus exporter
+    - name: download redis prometheus exporter
+      get_url:
+        url: "https://github.com/oliver006/redis_exporter/releases/download/v{{ redis_exporter_version }}/redis_exporter-v{{ redis_exporter_version }}.linux-amd64.tar.gz"
+        dest: "{{ dist_directory }}/ext/redis_exporter.tar.gz"
+
+    - name: decompress redis_exporter
+      shell: "tar xzvf redis_exporter.tar.gz"
+      args:
+        chdir: "{{ dist_directory }}/ext"
+
+    - name: get jmx prometheus exporter
+      get_url:
+        url: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/{{ jmx_prometheus_javaagent_version }}/jmx_prometheus_javaagent-{{ jmx_prometheus_javaagent_version }}.jar
+        dest: "{{ dist_directory }}/ext"
+
+    - name: download node exporter
+      get_url:
+        url: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz
+        dest: "{{ dist_directory }}/ext"
+
+    - name: decompress node_exporter
+      shell: "tar xzvf node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+      args:
+        chdir: "{{ dist_directory }}/ext"

--- a/hosts.template
+++ b/hosts.template
@@ -5,6 +5,7 @@ gateway
 storage
 
 [services:vars]
+dist_directory=./dist
 object_store_access_key=SZ1BBGKTD2N13E0W5L8N
 object_store_secret_key=qTsjiThBQA2NH6ZO32tCwCC6wcC8ValVLR16XUsB
 caliopen_domain_name=alpha.caliopen.org
@@ -36,7 +37,6 @@ worker
 
 [caliopen:vars]
 caliopen_version=0.4.0
-dist_directory=./dist
 web_client_cookie_secret=_4+%J;_F&?#!+mR&IsYq:Xg4A*wvse
 web_client_seal_secret=D}(2$5q)#_#yKX90,+0d5?4**a6ws8e`
 

--- a/roles/alertmanager/tasks/main.yml
+++ b/roles/alertmanager/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: install alertmanager
   copy:
-    src: "{{ dist_directory }}/ext/alertmanager-{{ alertmanager_version }}-linux-amd64/alertmanager"
+    src: "{{ dist_directory }}/ext/alertmanager-{{ alertmanager_version }}.linux-amd64/alertmanager"
     dest: /usr/local/sbin/alertmanager
     mode: 0711
 

--- a/roles/alertmanager/tasks/main.yml
+++ b/roles/alertmanager/tasks/main.yml
@@ -1,13 +1,8 @@
-- name: download alertmanager
-  get_url:
-    url: https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz
-    dest: /var/tmp
-
-- name: decompress alertmanager
-  unarchive:
-    src: /var/tmp/alertmanager-{{ alertmanager_version }}.linux-amd64.tar.gz
-    dest: /usr/local
-    remote_src: yes
+- name: install alertmanager
+  copy:
+    src: "{{ dist_directory }}/ext/alertmanager-{{ alertmanager_version }}-linux-amd64/alertmanager"
+    dest: /usr/local/sbin/alertmanager
+    mode: 0711
 
 - name: install service for alertmanager
   template: src=alertmanager.service.j2 dest=/etc/systemd/system/alertmanager.service

--- a/roles/cache/tasks/main.yml
+++ b/roles/cache/tasks/main.yml
@@ -7,17 +7,10 @@
   template: src=redis.conf.j2 dest=/etc/redis/redis.conf
   notify: restart redis
 
-- name: download redis prometheus exporter
-  get_url:
-    url: https://github.com/oliver006/redis_exporter/releases/download/v0.12.2/redis_exporter-v0.12.2.linux-amd64.tar.gz
-    dest: /var/tmp/redis_exporter.tar.gz
-
-- name: decompress redis_exporter
-  unarchive:
-    src: /var/tmp/redis_exporter.tar.gz
-    dest: /usr/local/bin/
-    remote_src: yes
-    owner: redis
+- name: install redis_exporter
+  copy:
+    src: "{{ dist_directory }}/ext/redis_exporter"
+    dest: /usr/local/sbin/redis_exporter
     mode: 0711
 
 - name: install redis_exporter service

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: configure cassandra
   template: src=cassandra.yaml.j2 dest=/etc/cassandra/cassandra.yaml
 
-- name: configure cassandra
+- name: configure cassandra environment
   template: src=cassandra-env.sh dest=/etc/cassandra/cassandra-env.sh
 
 - name: install cassandra

--- a/roles/cassandra/tasks/main.yml
+++ b/roles/cassandra/tasks/main.yml
@@ -31,10 +31,11 @@
     name: cassandra
     state: present
 
-- name: install jmx prometheus exporter
-  get_url:
-    url: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.9/jmx_prometheus_javaagent-0.9.jar
+- name: install jmx exporter
+  copy:
+    src: "{{ dist_directory }}/ext/jmx_prometheus_javaagent-{{ jmx_prometheus_javaagent_version }}.jar"
     dest: /etc/cassandra
+    mode: 0622
 
 - name: configure jmx exporter
   template: src=cassandra_exporter.yaml.j2 dest=/etc/cassandra/cassandra_exporter.yaml

--- a/roles/cassandra/templates/cassandra-env.sh
+++ b/roles/cassandra/templates/cassandra-env.sh
@@ -312,4 +312,4 @@ JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"
 
 # Add JMX prometheus exporter
 JMX_EXPORTER_DIR="/etc/cassandra/"
-JVM_OPTS="$JVM_OPTS -javaagent:$JMX_EXPORTER_DIR/jmx_prometheus_javaagent-0.9.jar=7070:$JMX_EXPORTER_DIR/cassandra_exporter.yaml"
+# JVM_OPTS="$JVM_OPTS -javaagent:$JMX_EXPORTER_DIR/jmx_prometheus_javaagent-{{ jmx_prometheus_javaagent_version }}.jar=7070:$JMX_EXPORTER_DIR/cassandra_exporter.yaml"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,18 +34,12 @@
 - name: force reload of fact
   setup:
 
-- name: download node exporter
-  unarchive:
-    src: https://github.com/prometheus/node_exporter/releases/download/v0.14.0/node_exporter-0.14.0.linux-amd64.tar.gz
-    dest: /var/tmp
-    remote_src: yes
-
-- name: install node exporter
+- name: install node_exporter
   copy:
-    src: /var/tmp/node_exporter-0.14.0.linux-amd64/node_exporter
-    dest: /usr/local/bin/node_exporter
-    remote_src: yes
-    mode: 0755
+    src: "{{ dist_directory }}/ext/node_exporter-{{ node_exporter_version }}.linux-amd64/node_exporter"
+    dest: /usr/local/sbin/node_exporter
+    mode: 0711
+
 
 - name: install node exporter service
   template: src=node-exporter.service.j2 dest=/etc/systemd/system/node-exporter.service

--- a/roles/common/templates/node-exporter.service.j2
+++ b/roles/common/templates/node-exporter.service.j2
@@ -3,8 +3,8 @@ Description=node exporter service
 
 [Service]
 Restart=always
-ExecStart=/usr/local/bin/node_exporter
-ExecStop=pkill node_exporter -web.listen-address {{ facter_network_eth1 }}:9100
+ExecStart=/usr/local/sbin/node_exporter -web.listen-address {{ facter_network_eth1 }}:9100
+ExecStop=pkill node_exporter 
 
 [Install]
 WantedBy=local.target

--- a/roles/nats/tasks/main.yml
+++ b/roles/nats/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: install nats
   copy:
-    src: "{{ dist_directory }}/ext/gnatsd-v{{ gnatsd_version }}-linux-amd64/gnatsd"
+    src: "{{ dist_directory }}/ext/gnatsd-v{{ gnats_version }}-linux-amd64/gnatsd"
     dest: /usr/local/sbin/gnatsd
     mode: 0711
 

--- a/roles/nats/tasks/main.yml
+++ b/roles/nats/tasks/main.yml
@@ -1,24 +1,7 @@
-- name: Install dependencies
-  action: apt pkg={{item}} state=installed
-  with_items:
-       - unzip
-
-- name: download nats server
-  get_url:
-    url: https://github.com/nats-io/gnatsd/releases/download/v1.0.2/gnatsd-v1.0.2-linux-amd64.zip
-    dest: /var/tmp/gnatsd.zip
-
-- name: unzip nats server
-  unarchive:
-    src: /var/tmp/gnatsd.zip
-    dest: /var/tmp/
-    remote_src: yes
-
 - name: install nats
   copy:
-    src: /var/tmp/gnatsd-v1.0.2-linux-amd64/gnatsd
+    src: "{{ dist_directory }}/ext/gnatsd-v{{ gnatsd_version }}-linux-amd64/gnatsd"
     dest: /usr/local/sbin/gnatsd
-    remote_src: yes
     mode: 0711
 
 - name: install gnats service


### PR DESCRIPTION
Get external dependencies not in system package on machine doing deployment.

Then upload these dependencies instead of let host download them from internet